### PR TITLE
Add localStorage persistence for log table

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,6 +348,10 @@ function formatDate(date){
 }
 let csvRows=[];
 let csvSessionDate=formatDate(new Date());
+function storeCsvData() {
+  localStorage.setItem('csvRows', JSON.stringify(csvRows));
+  localStorage.setItem('csvSessionDate', csvSessionDate);
+}
 function getStoredBaleCount(farmName) {
   const key = "lastBale_" + farmName.toLowerCase();
   const stored = localStorage.getItem(key);
@@ -391,11 +395,14 @@ function resetThisFarmSession() {
   baleCount = 0;
   sessionCount = 0;
   baleCountSet = false;
-     csvRows.push([]);
+  csvRows = [];
+  document.getElementById('logTable').querySelector('tbody').innerHTML = '';
+  document.getElementById('woolTypeTotals').querySelector('tbody').innerHTML = '';
   csvSessionDate = formatDate(new Date());
   updateDisplays();
 
   alert(`Reset complete for "${farmNameInput}". All bale data cleared for this farm.`);
+  storeCsvData();
 }
 
 function updateDisplays() {
@@ -421,6 +428,7 @@ function logBale(qrText) {
   baleCount++;
   updateDisplays();
   updateWoolTypeTotals(qrText.trim());
+  storeCsvData();
 }
 
 function startQRScan() {
@@ -501,29 +509,44 @@ const farmName = document.getElementById("station").value.trim();
 storeBaleCount(farmName, baleCount > 0 ? baleCount - 1 : 0);
 updateDisplays();
 console.log("Saving to storage:", farmName, "with bale count:", baleCount);
+ storeCsvData();
 }
 function exportCSV() {
-  const rows = [["#", "Wool Type", "Presser", "Farm", "Timestamp"], ...csvRows];
- 
-    
-    // Add Wool Type Totals
-  rows.push([]);
-  rows.push(["--- Wool Type Totals ---"]);
-  rows.push(["Wool Type", "Total Bales"]);
- const totalsTable = document.getElementById("woolTypeTotals").querySelector("tbody");
+  const station = document.getElementById("station").value.trim() || "Station";
+  const fileKey = `csvFile_${station}_${csvSessionDate}`;
+  let stored = JSON.parse(localStorage.getItem(fileKey) || "[]");
+
+  if (stored.length) {
+    stored.push([]); // spacer between sessions
+  }
+
+  let sessionRows = [["#", "Wool Type", "Presser", "Farm", "Timestamp"], ...csvRows];
+
+  // Add Wool Type Totals
+  sessionRows.push([]);
+  sessionRows.push(["--- Wool Type Totals ---"]);
+  sessionRows.push(["Wool Type", "Total Bales"]);
+  const totalsTable = document.getElementById("woolTypeTotals").querySelector("tbody");
   for (let row of totalsTable.rows) {
     const woolType = row.cells[0].textContent;
     const count = row.cells[1].textContent;
-    rows.push([woolType, count]);
+    sessionRows.push([woolType, count]);
   }
-const csvContent = rows.map(e => e.join(",")).join("\n");
+
+  stored = stored.concat(sessionRows);
+  localStorage.setItem(fileKey, JSON.stringify(stored));
+
+  const csvContent = stored.map(e => e.join(",")).join("\n");
   const blob = new Blob([csvContent], { type: "text/csv" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
-  const station = document.getElementById("station").value.trim() || "Station";
   a.setAttribute("href", url);
   a.setAttribute("download", `${station}_${csvSessionDate}.csv`);
   a.click();
+  URL.revokeObjectURL(url);
+  csvRows = [];
+  document.getElementById('logTable').querySelector('tbody').innerHTML = '';
+  storeCsvData();
 }
 
 function resetAllFarms() {
@@ -540,11 +563,14 @@ function resetAllFarms() {
   baleCount = 0;
   sessionCount = 0;
   baleCountSet = false;
-    csvRows.push([]);
+  csvRows = [];
+  document.getElementById('logTable').querySelector('tbody').innerHTML = '';
+  document.getElementById('woolTypeTotals').querySelector('tbody').innerHTML = '';
   csvSessionDate = formatDate(new Date());
   updateDisplays();
 
   alert("All farm bale counts have been reset.");
+  storeCsvData();
 }
 
 </script>
@@ -582,6 +608,33 @@ function updateWoolTypeTotals(woolType) {
   }
 }
 
+</script>
+<script>
+window.addEventListener('load', function() {
+  const today = formatDate(new Date());
+  const storedDate = localStorage.getItem('csvSessionDate');
+  if (storedDate === today) {
+    const storedRows = JSON.parse(localStorage.getItem('csvRows') || '[]');
+    csvRows = storedRows;
+    const table = document.getElementById('logTable').querySelector('tbody');
+    table.innerHTML = '';
+    storedRows.forEach(r => {
+      const row = table.insertRow();
+      r.forEach(val => {
+        row.insertCell().textContent = val;
+      });
+      updateWoolTypeTotals(r[1].trim());
+    });
+    sessionCount = storedRows.length;
+    baleCount = storedRows.length > 0 ? parseInt(storedRows[storedRows.length-1][0]) + 1 : baleCount;
+    baleCountSet = storedRows.length > 0;
+    csvSessionDate = storedDate;
+    updateDisplays();
+  } else {
+    localStorage.removeItem('csvRows');
+    localStorage.setItem('csvSessionDate', today);
+  }
+});
 </script>
     <script>
   if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- keep csv rows in localStorage and persist session date
- restore the log table from storage on load if the dates match
- automatically store csv data when rows are added or removed and when resets occur
- maintain daily CSV files with separate sessions appended

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68581cc2557083218136bb7cb6baa2a0