### PR TITLE
Remove Google UI remnants from index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
 <div class="scanner-header" style="text-align: center; margin-bottom: 1rem;">
     <h1 style="margin: 0; font-size: 1.8rem;">Bale Scanner</h1>
   </div>
-<button id="signInButton" disabled>Sign in with Google</button>
   <button class="new-day-button">New Farm/Day</button>
   <div style="position: absolute; top: 10px; right: 10px;">
 <button id="resetAllButton">Reset All</button>
@@ -43,7 +42,6 @@
 </div> 
 
 <button id="exportButton">End of Day</button>
-    <span id="pendingUploadsCounter" style="margin-left: 10px;">Pending Uploads: 0</span>
 <button id="deleteLastButton">Delete Last Entry</button>
     <button id="editTableButton">Edit Table</button>
 
@@ -73,10 +71,5 @@
 <source src="https://actions.google.com/sounds/v1/cartoon/wood_plank_flicks.ogg" type="audio/ogg"/>
 </audio>
 
-<script async defer src="https://apis.google.com/js/api.js"
-        onload="handleClientLoad()"
-        onerror="console.error('Google API failed to load');"></script>
-
-    
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove Google sign-in button and pending upload counter from the UI
- drop the Google API script tag now that Drive/OAuth logic is removed

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d8312bf6c8321afffc65af58b6e90)